### PR TITLE
Fixed image URL paste when not selected and dragged

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -675,7 +675,7 @@ export const Editable = (props: EditableProps) => {
 
               // If starting a drag on a void node, make sure it is selected
               // so that it shows up in the selection's fragment.
-              if (voidMatch) {
+              if (voidMatch || node.type === 'image') {
                 const range = Editor.range(editor, path)
                 Transforms.select(editor, range)
               }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a Bug

#### What's the new behavior?

![auto_select_drag_fix](https://user-images.githubusercontent.com/25941773/97099802-5686d500-164a-11eb-8e84-62e0c05807f3.gif)

The change auto selects the image node that is dragged. 

#### How does this change work?

This change builds off of @llevequeblup  's PR where dragged images copy and paste instead of drag and drop.
This change fixes the follow up bug/issue where, when non selected images are dragged it pastes its URL instead of dragging and dropping the image.

This change happens in editable onDragStart, when the node that was dragged is of type image, we auto select it so when onDrop happens, we can insert the selected image.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #3137
